### PR TITLE
Initialize Electron MCP Config Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+/dist

--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
-# mcp-config-manager
-mcp 설정을 돕는 데스크톱 앱 입니다.
+# MCP Config Manager
+
+Desktop app for viewing and editing Claude Desktop MCP settings.
+
+## Prerequisites
+- Node.js 18+
+- npm or Yarn
+
+## Development
+```bash
+npm install
+npm run dev
+```
+
+## Build
+```bash
+npm run build
+```
+
+## Package
+```bash
+npm run package:win   # Windows installer
+npm run package:mac   # macOS DMG
+npm run package:linux # Linux AppImage
+```
+
+## Example MCP Config
+```json
+{
+  "mcpServers": {
+    "sqlite": { "command": "run-sqlite" },
+    "filesystem": { "command": "run-fs" },
+    "notion": { "command": "run-notion" }
+  }
+}
+```

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'electron-vite';
+import { resolve } from 'path';
+
+export default defineConfig({
+  main: {
+    entry: 'src/main/index.ts',
+    vite: {
+      build: {
+        outDir: 'dist/main'
+      }
+    }
+  },
+  renderer: {
+    entry: 'src/renderer/main.ts',
+    vite: {
+      build: {
+        outDir: 'dist/renderer'
+      }
+    }
+  }
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  roots: ['<rootDir>/tests/unit'],
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.ts$': 'ts-jest'
+  },
+  moduleFileExtensions: ['ts', 'js'],
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "mcp-config-manager",
+  "version": "1.0.0",
+  "description": "Desktop app to manage Claude MCP settings",
+  "main": "dist/main/index.js",
+  "scripts": {
+    "dev": "electron-forge start",
+    "build": "electron-vite build",
+    "package:win": "electron-builder --win",
+    "package:mac": "electron-builder --mac",
+    "package:linux": "electron-builder --linux",
+    "test": "jest"
+  },
+  "devDependencies": {
+    "electron": "^25.0.0",
+    "electron-builder": "^23.6.0",
+    "electron-vite": "^2.0.0",
+    "electron-forge": "^6.1.0",
+    "typescript": "^5.0.0",
+    "vue": "^3.3.0",
+    "pinia": "^2.1.0",
+    "jest": "^29.0.0",
+    "spectron": "^15.0.0"
+  },
+  "dependencies": {
+    "winston": "^3.8.1"
+  },
+  "build": {
+    "appId": "com.example.mcpconfigmanager",
+    "asar": true,
+    "files": [
+      "dist/**/*"
+    ],
+    "extraFiles": [],
+    "mac": {
+      "target": ["dmg", "zip"],
+      "category": "public.app-category.utilities"
+    },
+    "win": {
+      "target": [
+        {
+          "target": "nsis",
+          "arch": ["x64"]
+        },
+        {
+          "target": "portable",
+          "arch": ["x64"]
+        }
+      ]
+    },
+    "linux": {
+      "target": ["AppImage"],
+      "maintainer": "mcp",
+      "category": "Utility"
+    }
+  }
+}

--- a/src/main/configUtil.ts
+++ b/src/main/configUtil.ts
@@ -1,0 +1,24 @@
+// Utility functions for config validation
+export interface McpServers {
+  [key: string]: {
+    command: string;
+    args?: string[];
+    env?: Record<string, string>;
+    enabled?: boolean;
+  };
+}
+
+export interface McpConfig {
+  mcpServers?: McpServers;
+  [key: string]: any;
+}
+
+export function filterEnabledServers(servers: McpServers): McpServers {
+  const out: McpServers = {};
+  Object.entries(servers).forEach(([k, v]) => {
+    if (v.enabled === false) return;
+    const { enabled, ...rest } = v as any;
+    out[k] = rest;
+  });
+  return out;
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,0 +1,121 @@
+// Main process entry for MCP Config Manager
+import { app, BrowserWindow, ipcMain } from 'electron';
+import path from 'path';
+import fs from 'fs';
+import { format, transports, createLogger } from 'winston';
+
+const userData = app.getPath('userData');
+const logDir = path.join(userData, 'logs');
+const logPath = path.join(logDir, 'app.log');
+
+// ensure log directory exists
+if (!fs.existsSync(logDir)) {
+  fs.mkdirSync(logDir, { recursive: true });
+}
+
+const logger = createLogger({
+  level: 'info',
+  format: format.combine(
+    format.timestamp(),
+    format.printf((info) => `${info.timestamp} [${info.level}] ${info.message}`),
+  ),
+  transports: [
+    new transports.File({ filename: logPath }),
+  ],
+});
+
+let mainWindow: BrowserWindow | null = null;
+
+function createWindow() {
+  mainWindow = new BrowserWindow({
+    width: 1024,
+    height: 768,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+      nodeIntegration: false,
+      contextIsolation: true,
+    },
+  });
+
+  if (app.isPackaged) {
+    mainWindow.loadFile(path.join(__dirname, '../renderer/index.html'));
+  } else {
+    mainWindow.loadURL('http://localhost:5173');
+  }
+}
+
+app.whenReady().then(createWindow);
+
+function getConfigPath(): string {
+  // naive implementation. Real implementation may read registry or env.
+  const base = app.getPath('appData');
+  return path.join(base, 'ClaudeMCP', 'config.json');
+}
+
+function readConfig() {
+  const cfgPath = getConfigPath();
+  if (!fs.existsSync(cfgPath)) {
+    return {};
+  }
+  const raw = fs.readFileSync(cfgPath, 'utf-8');
+  return JSON.parse(raw);
+}
+
+function writeConfig(data: any) {
+  const cfgPath = getConfigPath();
+  const backupPath = `${cfgPath}.${Date.now()}.bak`;
+  if (fs.existsSync(cfgPath)) {
+    fs.copyFileSync(cfgPath, backupPath);
+  }
+  fs.writeFileSync(cfgPath, JSON.stringify(data, null, 2));
+}
+
+ipcMain.handle('getConfig', async () => {
+  try {
+    const cfg = readConfig();
+    logger.info('Config read');
+    return { success: true, config: cfg };
+  } catch (err: any) {
+    logger.error(`getConfig error: ${err.message}`);
+    return { success: false, message: err.message };
+  }
+});
+
+ipcMain.handle('setConfig', async (_event, payload) => {
+  try {
+    const cfg = payload;
+    // filter disabled servers
+    if (cfg.mcpServers) {
+      const filtered: Record<string, any> = {};
+      Object.entries(cfg.mcpServers).forEach(([key, val]: [string, any]) => {
+        if (!val || val.enabled === false) return;
+        const { enabled, ...rest } = val;
+        filtered[key] = rest;
+      });
+      cfg.mcpServers = filtered;
+    }
+    writeConfig(cfg);
+    logger.info('Config written');
+    return { success: true };
+  } catch (err: any) {
+    logger.error(`setConfig error: ${err.message}`);
+    return { success: false, message: err.message };
+  }
+});
+
+ipcMain.handle('applyConfig', async () => {
+  try {
+    // TODO: signal Claude app to reload config
+    logger.info('applyConfig triggered');
+    return { success: true };
+  } catch (err: any) {
+    logger.error(`applyConfig error: ${err.message}`);
+    return { success: false, message: err.message };
+  }
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,0 +1,8 @@
+// Preload script exposes safe IPC APIs to renderer
+import { contextBridge, ipcRenderer } from 'electron';
+
+contextBridge.exposeInMainWorld('mcpAPI', {
+  getConfig: () => ipcRenderer.invoke('getConfig'),
+  setConfig: (data: any) => ipcRenderer.invoke('setConfig', data),
+  applyConfig: () => ipcRenderer.invoke('applyConfig'),
+});

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -1,0 +1,33 @@
+<template>
+  <div class="app">
+    <aside class="sidebar">
+      <ul>
+        <li>Profiles</li>
+        <li>MCP 서버</li>
+        <li>Settings</li>
+        <li>About</li>
+      </ul>
+    </aside>
+    <main class="panel">
+      <router-view />
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+// Layout only; logic in views
+</script>
+
+<style scoped>
+.app {
+  display: flex;
+}
+.sidebar {
+  width: 200px;
+  background: #f0f0f0;
+}
+.panel {
+  flex: 1;
+  padding: 16px;
+}
+</style>

--- a/src/renderer/env.d.ts
+++ b/src/renderer/env.d.ts
@@ -1,0 +1,7 @@
+interface Window {
+  mcpAPI: {
+    getConfig: () => Promise<any>;
+    setConfig: (data: any) => Promise<any>;
+    applyConfig: () => Promise<any>;
+  };
+}

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MCP Config Manager</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -1,0 +1,10 @@
+// Renderer entry mounting Vue app
+import { createApp } from 'vue';
+import { createPinia } from 'pinia';
+import App from './App.vue';
+import router from './router';
+
+const app = createApp(App);
+app.use(createPinia());
+app.use(router);
+app.mount('#app');

--- a/src/renderer/router.ts
+++ b/src/renderer/router.ts
@@ -1,0 +1,9 @@
+import { createRouter, createWebHashHistory } from 'vue-router';
+import SettingsView from './views/SettingsView.vue';
+
+export default createRouter({
+  history: createWebHashHistory(),
+  routes: [
+    { path: '/', component: SettingsView },
+  ],
+});

--- a/src/renderer/store/mcpStore.ts
+++ b/src/renderer/store/mcpStore.ts
@@ -1,0 +1,14 @@
+import { defineStore } from 'pinia';
+
+export const useMcpStore = defineStore('mcp', {
+  actions: {
+    async apply(servers: Record<string, any>) {
+      const cfg = { mcpServers: servers };
+      await window.mcpAPI.applyConfig(cfg);
+    },
+    async save(baseConfig: any, servers: Record<string, any>) {
+      const cfg = { ...baseConfig, mcpServers: servers };
+      await window.mcpAPI.setConfig(cfg);
+    },
+  },
+});

--- a/src/renderer/views/SettingsView.vue
+++ b/src/renderer/views/SettingsView.vue
@@ -1,0 +1,46 @@
+<template>
+  <div>
+    <h2>MCP Settings</h2>
+    <div v-if="config">
+      <div v-for="(srv, key) in servers" :key="key" class="server-row">
+        <label>{{ key }}</label>
+        <input type="checkbox" v-model="srv.enabled" />
+      </div>
+      <button @click="apply">Apply</button>
+      <button @click="save">Save</button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, reactive } from 'vue';
+import { useMcpStore } from '../store/mcpStore';
+
+const store = useMcpStore();
+const config = reactive<{ [key: string]: any }>({});
+const servers = reactive<{ [key: string]: any }>({});
+
+onMounted(async () => {
+  const res = await window.mcpAPI.getConfig();
+  if (res.success) {
+    Object.assign(config, res.config);
+    Object.assign(servers, res.config.mcpServers || {});
+    // restore enabled flag
+    Object.entries(servers).forEach(([k, v]: [string, any]) => {
+      if (v) v.enabled = true;
+    });
+  }
+});
+
+function apply() {
+  store.apply(servers);
+}
+
+function save() {
+  store.save(config, servers);
+}
+</script>
+
+<style scoped>
+.server-row { margin: 4px 0; }
+</style>

--- a/tests/e2e/app.test.ts
+++ b/tests/e2e/app.test.ts
@@ -1,0 +1,15 @@
+const { Application } = require('spectron');
+const path = require('path');
+
+describe('App launch', () => {
+  test('shows window', async () => {
+    const app = new Application({
+      path: path.join(__dirname, '../../node_modules/.bin/electron'),
+      args: [path.join(__dirname, '../../dist/main')],
+    });
+    await app.start();
+    const count = await app.client.getWindowCount();
+    expect(count).toBeGreaterThan(0);
+    await app.stop();
+  });
+});

--- a/tests/unit/configUtil.test.ts
+++ b/tests/unit/configUtil.test.ts
@@ -1,0 +1,13 @@
+import { filterEnabledServers } from '../../src/main/configUtil';
+
+describe('filterEnabledServers', () => {
+  test('removes disabled entries', () => {
+    const input = {
+      sqlite: { command: 'run', enabled: true },
+      notion: { command: 'run', enabled: false },
+    };
+    const result = filterEnabledServers(input as any);
+    expect(result.notion).toBeUndefined();
+    expect(result.sqlite.command).toBe('run');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "strict": true,
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- bootstrap electron-vite project for MCP settings
- add Vue 3 renderer with Pinia store
- implement main IPC handlers with winston logs
- add simple unit and e2e test skeletons
- include packaging and usage instructions

## Testing
- `npm test` *(fails: jest not found)*