### PR TITLE
Add config utilities and tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/tests/**/*.test.ts', '!**/tests/e2e/**'],
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "mcp-config-manager",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "npm run test:unit && npm run test:e2e",
+    "test:unit": "jest",
+    "test:e2e": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.42.0",
+    "jest": "^29.0.0",
+    "ts-jest": "^29.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,5 @@
+import type { PlaywrightTestConfig } from '@playwright/test';
+const config: PlaywrightTestConfig = {
+  testDir: 'tests/e2e'
+};
+export default config;

--- a/src/main/configUtil.ts
+++ b/src/main/configUtil.ts
@@ -1,0 +1,24 @@
+export interface ServerConfig {
+  name: string;
+  enabled: boolean;
+}
+
+export interface AppState {
+  servers: Record<string, ServerConfig>;
+}
+
+export function toggleServer(state: AppState, serverName: string): AppState {
+  const server = state.servers[serverName];
+  if (!server) {
+    throw new Error(`Server ${serverName} not found`);
+  }
+  const updated: ServerConfig = { ...server, enabled: !server.enabled };
+  return {
+    ...state,
+    servers: { ...state.servers, [serverName]: updated }
+  };
+}
+
+export function isServerEnabled(state: AppState, serverName: string): boolean {
+  return !!state.servers[serverName]?.enabled;
+}

--- a/tests/configUtil.test.ts
+++ b/tests/configUtil.test.ts
@@ -1,0 +1,19 @@
+import { toggleServer, isServerEnabled, AppState } from '../src/main/configUtil';
+
+describe('configUtil', () => {
+  test('toggleServer flips enabled state', () => {
+    const initial: AppState = { servers: { a: { name: 'a', enabled: false } } };
+    const updated = toggleServer(initial, 'a');
+    expect(updated.servers.a.enabled).toBe(true);
+  });
+
+  test('toggleServer throws if server missing', () => {
+    const initial: AppState = { servers: {} };
+    expect(() => toggleServer(initial, 'nope')).toThrow('Server nope not found');
+  });
+
+  test('isServerEnabled returns current state', () => {
+    const initial: AppState = { servers: { b: { name: 'b', enabled: true } } };
+    expect(isServerEnabled(initial, 'b')).toBe(true);
+  });
+});

--- a/tests/e2e/toggleServer.test.ts
+++ b/tests/e2e/toggleServer.test.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+import { toggleServer, AppState } from '../../src/main/configUtil';
+
+test('toggle server updates state', async () => {
+  const state: AppState = { servers: { a: { name: 'a', enabled: false } } };
+  const updated = toggleServer(state, 'a');
+  expect(updated.servers.a.enabled).toBe(true);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}


### PR DESCRIPTION
## Summary
- add basic config utilities
- add unit tests
- add simple Playwright test
- wire up npm test for both unit and e2e

## Testing
- `npm test` *(fails: jest not found)*