### PR TITLE
Add Electron-Vue MCP config manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,38 @@
-# mcp-config-manager
-mcp 설정을 돕는 데스크톱 앱 입니다.
+# MCP Config Manager
+
+Electron + Vue 3 desktop app for editing Claude MCP settings.
+
+## Prerequisites
+- Node.js 18+
+- npm or yarn
+
+## Development
+```bash
+npm install
+npm run dev
+```
+
+## Build
+```bash
+npm run build
+```
+
+## Package
+```bash
+npm run package:win # Windows
+npm run package:mac # macOS
+npm run package:linux # Linux
+```
+
+## Example MCP Config
+```json
+{
+  "micVolume": 70,
+  "noiseSuppressionLevel": 3,
+  "mcpServers": {
+    "sqlite": { "command": "run-sqlite" },
+    "filesystem": { "command": "run-fs" },
+    "notion": { "command": "run-notion" }
+  }
+}
+```

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'electron-vite';
+import { resolve } from 'path';
+
+export default defineConfig({
+  main: {
+    entry: 'src/main/index.ts',
+  },
+  preload: {
+    // not used
+  },
+  renderer: {
+    entry: 'src/renderer/main.ts',
+    viteConfig: {
+      resolve: {
+        alias: {
+          '@': resolve(__dirname, 'src/renderer'),
+        },
+      },
+    },
+  },
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/tests/unit'],
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "mcp-config-manager",
+  "version": "1.0.0",
+  "description": "Desktop app to manage Claude MCP settings",
+  "main": "src/main/index.ts",
+  "scripts": {
+    "dev": "electron-forge start",
+    "build": "electron-vite build",
+    "package:win": "electron-builder --win",
+    "package:mac": "electron-builder --mac",
+    "package:linux": "electron-builder --linux",
+    "test": "jest",
+    "test:e2e": "playwright test"
+  },
+  "build": {
+    "appId": "com.example.mcpconfig",
+    "productName": "MCP Config Manager",
+    "files": [
+      "dist/**/*"
+    ],
+    "asar": true,
+    "directories": {
+      "output": "release"
+    },
+    "win": {
+      "target": [
+        {
+          "target": "nsis",
+          "arch": [
+            "x64"
+          ]
+        },
+        "portable"
+      ]
+    },
+    "mac": {
+      "target": [
+        "dmg",
+        "dir"
+      ],
+      "sign": true
+    },
+    "linux": {
+      "target": "AppImage"
+    }
+  },
+  "devDependencies": {
+    "@electron-forge/cli": "^7.7.0",
+    "@electron-forge/maker-deb": "^7.7.0",
+    "@electron-forge/maker-rpm": "^7.7.0",
+    "@electron-forge/maker-squirrel": "^7.7.0",
+    "@electron-forge/maker-zip": "^7.7.0",
+    "@types/jest": "^29.5.0",
+    "@types/node": "^20.5.0",
+    "electron": "^26.2.0",
+    "electron-builder": "^24.6.0",
+    "electron-vite": "^1.1.0",
+    "jest": "^29.5.0",
+    "playwright": "^1.32.0",
+    "ts-jest": "^29.1.0",
+    "typescript": "^5.1.0",
+    "vue-tsc": "^1.2.0",
+    "vue": "^3.3.4",
+    "vue-loader": "^17.0.1",
+    "pinia": "^2.0.28"
+  },
+  "dependencies": {
+    "winston": "^3.9.0",
+    "zod": "^3.22.2"
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: 'tests/e2e',
+  use: {
+    headless: true,
+  },
+});

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,0 +1,109 @@
+// MCP Config Manager main process
+// Handles window creation and IPC for config management
+
+import { app, BrowserWindow, ipcMain } from 'electron';
+import { join } from 'path';
+import { promises as fs } from 'fs';
+import os from 'os';
+import { format } from 'date-fns';
+import winston from 'winston';
+
+// Logger setup writes logs into user data folder
+const logDir = join(app.getPath('userData'), 'logs');
+const logger = winston.createLogger({
+  level: 'info',
+  transports: [
+    new winston.transports.File({ filename: join(logDir, 'app.log') }),
+  ],
+});
+
+let mainWindow: BrowserWindow | null = null;
+
+function createWindow() {
+  mainWindow = new BrowserWindow({
+    width: 1000,
+    height: 700,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false,
+    },
+  });
+  mainWindow.loadURL(import.meta.env.DEV ? 'http://localhost:5173' : `file://${join(__dirname, '../renderer/index.html')}`);
+}
+
+app.whenReady().then(() => {
+  createWindow();
+
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});
+
+// Config path resolution: attempt OS specific paths
+function getConfigPath() {
+  const base = process.platform === 'win32'
+    ? join(os.homedir(), 'AppData', 'Roaming', 'Claude')
+    : join(os.homedir(), '.config', 'Claude');
+  return join(base, 'mcp.json');
+}
+
+async function readConfig() {
+  const file = getConfigPath();
+  try {
+    const data = await fs.readFile(file, 'utf-8');
+    return JSON.parse(data);
+  } catch (err) {
+    logger.error(`Failed to read config: ${err}`);
+    throw err;
+  }
+}
+
+async function writeConfig(newConfig: any) {
+  const file = getConfigPath();
+  const backupName = `${file}.${format(new Date(), 'yyyyMMddHHmmss')}.bak`;
+  try {
+    const current = await fs.readFile(file, 'utf-8');
+    await fs.mkdir(logDir, { recursive: true });
+    await fs.writeFile(backupName, current);
+    await fs.writeFile(file, JSON.stringify(newConfig, null, 2));
+  } catch (err) {
+    logger.error(`Failed to write config: ${err}`);
+    throw err;
+  }
+}
+
+// IPC handlers
+ipcMain.handle('getConfig', async () => {
+  logger.info('getConfig called');
+  return readConfig();
+});
+
+ipcMain.handle('setConfig', async (_evt, cfg) => {
+  logger.info('setConfig called');
+  // keep only enabled servers
+  if (cfg.mcpServers) {
+    const filtered: Record<string, any> = {};
+    Object.keys(cfg.mcpServers).forEach((key) => {
+      if (cfg.mcpServers[key].enabled !== false) {
+        const cpy = { ...cfg.mcpServers[key] };
+        delete cpy.enabled;
+        filtered[key] = cpy;
+      }
+    });
+    cfg.mcpServers = filtered;
+  }
+  await writeConfig(cfg);
+  return true;
+});
+
+ipcMain.handle('applyConfig', async () => {
+  logger.info('applyConfig called');
+  // Placeholder: signal Claude to reload config
+  return true;
+});

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -1,0 +1,31 @@
+<template>
+  <div class="app-container">
+    <Sidebar @select="currentView = $event" />
+    <main class="main-panel">
+      <ConfigPanel v-if="currentView === 'mcp'" />
+      <SettingsPanel v-else-if="currentView === 'settings'" />
+      <AboutPanel v-else-if="currentView === 'about'" />
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import Sidebar from './components/Sidebar.vue';
+import ConfigPanel from './components/ConfigPanel.vue';
+import SettingsPanel from './components/SettingsPanel.vue';
+import AboutPanel from './components/AboutPanel.vue';
+
+const currentView = ref('mcp');
+</script>
+
+<style>
+.app-container {
+  display: flex;
+  height: 100vh;
+}
+.main-panel {
+  flex-grow: 1;
+  padding: 1rem;
+}
+</style>

--- a/src/renderer/components/AboutPanel.vue
+++ b/src/renderer/components/AboutPanel.vue
@@ -1,0 +1,9 @@
+<template>
+  <div>
+    <h2>About MCP Config Manager</h2>
+    <p>Version 1.0.0</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+</script>

--- a/src/renderer/components/ConfigPanel.vue
+++ b/src/renderer/components/ConfigPanel.vue
@@ -1,0 +1,35 @@
+<template>
+  <div>
+    <h2>MCP 서버</h2>
+    <div v-for="(server, key) in servers" :key="key" class="server-row">
+      <label>
+        <input type="checkbox" v-model="server.enabled" />
+        {{ key }} - {{ server.command }}
+      </label>
+    </div>
+    <button @click="apply">Apply</button>
+    <button @click="save">Save</button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useConfigStore } from '../store/config';
+
+const store = useConfigStore();
+const servers = store.servers;
+
+function apply() {
+  store.apply();
+}
+function save() {
+  store.save();
+}
+</script>
+
+<style>
+.server-row {
+  display: flex;
+  align-items: center;
+  margin-bottom: 4px;
+}
+</style>

--- a/src/renderer/components/SettingsPanel.vue
+++ b/src/renderer/components/SettingsPanel.vue
@@ -1,0 +1,26 @@
+<template>
+  <div>
+    <h2>Settings</h2>
+    <label>
+      Mic Volume
+      <input type="range" v-model="settings.micVolume" min="0" max="100" />
+    </label>
+    <label>
+      Noise Suppression
+      <select v-model="settings.noiseSuppressionLevel">
+        <option v-for="n in 5" :key="n" :value="n">{{ n }}</option>
+      </select>
+    </label>
+    <button @click="apply">Apply</button>
+    <button @click="save">Save</button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useConfigStore } from '../store/config';
+const store = useConfigStore();
+const settings = store.config;
+
+function apply() { store.apply(); }
+function save() { store.save(); }
+</script>

--- a/src/renderer/components/Sidebar.vue
+++ b/src/renderer/components/Sidebar.vue
@@ -1,0 +1,38 @@
+<template>
+  <nav class="sidebar">
+    <ul>
+      <li :class="{ active: current==='mcp' }" @click="select('mcp')">MCP 서버</li>
+      <li :class="{ active: current==='profiles' }" @click="select('profiles')">Profiles</li>
+      <li :class="{ active: current==='settings' }" @click="select('settings')">Settings</li>
+      <li :class="{ active: current==='about' }" @click="select('about')">About</li>
+    </ul>
+  </nav>
+</template>
+
+<script setup lang="ts">
+const emit = defineEmits(['select']);
+const current = ref('mcp');
+
+function select(view: string) {
+  current.value = view;
+  emit('select', view);
+}
+</script>
+
+<style>
+.sidebar {
+  width: 200px;
+  background: #eee;
+}
+.sidebar ul {
+  list-style: none;
+  padding: 0;
+}
+.sidebar li {
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+.sidebar li.active {
+  background: #ccc;
+}
+</style>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>MCP Config Manager</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -1,0 +1,9 @@
+// Entry for renderer process (Vue 3)
+
+import { createApp } from 'vue';
+import { createPinia } from 'pinia';
+import App from './App.vue';
+
+const app = createApp(App);
+app.use(createPinia());
+app.mount('#app');

--- a/src/renderer/store/config.ts
+++ b/src/renderer/store/config.ts
@@ -1,0 +1,29 @@
+import { defineStore } from 'pinia';
+import { ipcRenderer } from 'electron';
+import { reactive } from 'vue';
+
+export const useConfigStore = defineStore('config', () => {
+  const config = reactive<any>({});
+  const servers = reactive<Record<string, any>>({});
+
+  async function load() {
+    const data = await ipcRenderer.invoke('getConfig');
+    Object.assign(config, data);
+    if (data.mcpServers) {
+      Object.entries(data.mcpServers).forEach(([key, val]: [string, any]) => {
+        servers[key] = { ...val, enabled: true };
+      });
+    }
+  }
+
+  async function apply() {
+    await ipcRenderer.invoke('applyConfig');
+  }
+
+  async function save() {
+    const cfg = { ...config, mcpServers: { ...servers } };
+    await ipcRenderer.invoke('setConfig', cfg);
+  }
+
+  return { config, servers, load, apply, save };
+});

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -1,0 +1,21 @@
+// Shared helpers for config parsing and validation
+import { z } from 'zod';
+
+export const serverSchema = z.object({
+  command: z.string(),
+  args: z.array(z.string()).optional(),
+  env: z.record(z.string()).optional(),
+  enabled: z.boolean().optional(),
+});
+
+export const configSchema = z.object({
+  mcpServers: z.record(serverSchema).optional(),
+  micVolume: z.number().optional(),
+  noiseSuppressionLevel: z.number().optional(),
+});
+
+export type MCPConfig = z.infer<typeof configSchema>;
+
+export function parseConfig(data: any): MCPConfig {
+  return configSchema.parse(data);
+}

--- a/tests/e2e/basic.spec.ts
+++ b/tests/e2e/basic.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+
+// Simple e2e test launching the renderer standalone
+
+test('load UI', async ({ page }) => {
+  await page.goto('http://localhost:5173');
+  await expect(page.locator('text=MCP 서버')).toBeVisible();
+});

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -1,0 +1,12 @@
+import { parseConfig } from '../../src/shared/config';
+
+describe('parseConfig', () => {
+  it('parses valid config', () => {
+    const data = { micVolume: 50, mcpServers: { sqlite: { command: 'run' } } };
+    expect(parseConfig(data)).toBeTruthy();
+  });
+
+  it('throws on invalid config', () => {
+    expect(() => parseConfig({ micVolume: 'bad' })).toThrow();
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- initialize Electron Forge+Vite project structure
- add Electron main process with IPC for config management
- add Vue 3 renderer with Pinia store and basic panels
- configure electron-builder packaging
- add unit and e2e test skeletons
- provide README with usage instructions

## Testing
- `npm test` *(fails: jest not found)*
- `npm run test:e2e` *(fails: playwright not found)*